### PR TITLE
增加两种政策

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ npm run dev
 
 # build for production and view the bundle analyzer report
 # npm run build --report
+
+# Test
+# run `./vendor/bin/phpunit [testFile]`, eg. `tests/Feature/ResourcePolicyTest.php`
 ```
 
 ## 开发

--- a/app/Http/Controllers/Common/ResourceController.php
+++ b/app/Http/Controllers/Common/ResourceController.php
@@ -136,6 +136,7 @@ class ResourceController extends Controller
                 return response($result['info'], $result['status']);
             }
 
+            // 增加资源
             if (is_string($result['info'])) {
                 $resource = Resource::where('userId', Auth::id())->first();
                 $resource->people += $endResult;
@@ -168,6 +169,141 @@ class ResourceController extends Controller
      * @number 50
      */
     public function stopEnlisting(int $x, int $y)
+    {
+        // 启动政策
+        $coordinate = explode(',', Auth::user()->capital);
+        DB::beginTransaction();
+        try {
+            $result = (new Policy())->stopWithMe($coordinate[0], $coordinate[1]);
+
+            if ($result['status'] !== 200) {
+                DB::rollBack();
+                return response($result['info'], $result['status']);
+            }
+            DB::commit();
+            return $result['info'];
+        } catch (\Exception $exception) {
+            DB::rollBack();
+            return response($exception->getMessage(), 500);
+        }
+    }
+
+    /**
+     * showdoc
+     * @catalog 前后端接口/领地
+     * @title [动作]发布流民招募启示
+     * @description 在坐标为 X,Y 的领土上，施展政令。该政令耗费 10 金钱，返回政令的结束时间戳，届时，需前端发起请求，获取该政令的状态并提示给用户
+     * @method get
+     * @url https://{url}/lord/policy/enlisting/open/{x}/{y}
+     * @param x 必选 int X坐标
+     * @param y 必选 int Y坐标
+     * @return {1546777084}
+     * @return_param - int|string 政令完成的时间戳或失败原因
+     * @number 50
+     */
+    public function openDeported(int $x, int $y)
+    {
+        // 扣除资源
+        $resource = Resource::where('userId', Auth::id())->first();
+        if ($resource->money < 10) {
+            return response('大爷，咱们的钱不够啦！', 400);
+        }
+        $resource->money -= 10;
+        DB::beginTransaction();
+        try {
+            if (!$resource->save()) {
+                return '失败：付钱行为无法保存';
+            }
+
+            // 启动政策
+            $endTime = Policy::POLICIES_ENLISTING['time'] + $_SERVER['REQUEST_TIME'];
+            $coordinate = explode(',', Auth::user()->capital);
+            $result = (new Policy())->addWithMe($coordinate[0], $coordinate[1], Policy::POLICIES_ENLISTING['id'], $endTime);
+
+            if ($result['status'] !== 200) {
+                DB::rollBack();
+                return response($result['info'], $result['status']);
+            }
+            DB::commit();
+            return $result['info'];
+        } catch (\Exception $exception) {
+            DB::rollBack();
+            return response($exception->getMessage(), 500);
+        }
+    }
+
+    /**
+     * showdoc
+     * @catalog 前后端接口/领地
+     * @title [动作]流民招募启示的进度
+     * @description -
+     * @method get
+     * @url https://{url}/lord/policy/enlisting/know/{x}/{y}
+     * @param x 必选 int X坐标
+     * @param y 必选 int Y坐标
+     * @return {"id":26,"created_at":"2018-12-22 12:45:57","updated_at":"2018-12-24 01:24:47"}
+     * @return_param id int 资源ID
+     * @return_param created_at int 创建时间
+     * @return_param updated_at int 更新时间
+     * @number 50
+     */
+    public function knowDeported(int $x, int $y)
+    {
+        // 启动政策
+        $coordinate = explode(',', Auth::user()->capital);
+        $percent = rand(1, 100);
+        // 10% 1-2; 60% 3-6; 30% 7-10; sum: 21.3
+        if ($percent < 10) {
+            $endResult = rand(1, 2);
+        } elseif ($percent < 70) {
+            $endResult = rand(3, 6);
+        } else {
+            $endResult = rand(7, 10);
+        }
+        $endInfo = '政策“' . Policy::POLICIES_TRANS[1] . '”已结束，有' . $endResult . '位流浪人投靠我们。';
+
+        DB::beginTransaction();
+        try {
+            $result = (new Policy())->getStatus($coordinate[0], $coordinate[1], Auth::id(), $endInfo);
+
+            if ($result['status'] !== 200) {
+                DB::rollBack();
+                return response($result['info'], $result['status']);
+            }
+
+            // 增加资源
+            if (is_string($result['info'])) {
+                $resource = Resource::where('userId', Auth::id())->first();
+                $resource->people += $endResult;
+                if (!$resource->save()) {
+                    throw new \Exception('保存新增流浪人失败');
+                }
+            }
+
+            DB::commit();
+            return $result['info'];
+        } catch (\Exception $exception) {
+            DB::rollBack();
+            return response($exception->getMessage(), 500);
+        }
+    }
+
+    /**
+     * showdoc
+     * @catalog 前后端接口/领地
+     * @title [动作]终止流民招募启示
+     * @description 直接结束招募，但不退还发执行政令的费用
+     * @method get
+     * @url https://{url}/lord/policy/enlisting/stop/{x}/{y}
+     * @param x 必选 int X坐标
+     * @param y 必选 int Y坐标
+     * @return {"id":26,"created_at":"2018-12-22 12:45:57","updated_at":"2018-12-24 01:24:47"}
+     * @return_param id int 资源ID
+     * @return_param created_at int 创建时间
+     * @return_param updated_at int 更新时间
+     * @number 50
+     */
+    public function stopDeported(int $x, int $y)
     {
         // 启动政策
         $coordinate = explode(',', Auth::user()->capital);

--- a/app/Http/Controllers/Common/ResourceController.php
+++ b/app/Http/Controllers/Common/ResourceController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers\Common;
 
 use App\Models\Resource;
 use App\Policy;
-use App\Service\LogService;
 use Illuminate\Support\Facades\Auth;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\DB;
@@ -60,14 +59,14 @@ class ResourceController extends Controller
      * @title [动作]发布流民招募启示
      * @description 在坐标为 X,Y 的领土上，施展政令。该政令耗费 10 金钱，返回政令的结束时间戳，届时，需前端发起请求，获取该政令的状态并提示给用户
      * @method get
-     * @url https://{url}/lord/policy/enlisting/open
-     * @param x 必选 int X 坐标
-     * @param y 必选 int Y 坐标
+     * @url https://{url}/lord/policy/enlisting/open/{x}/{y}
+     * @param x 必选 int X坐标
+     * @param y 必选 int Y坐标
      * @return {1546777084}
      * @return_param - int|string 政令完成的时间戳或失败原因
      * @number 50
      */
-    public function openEnlisting()
+    public function openEnlisting(int $x, int $y)
     {
         // 扣除资源
         $resource = Resource::where('userId', Auth::id())->first();
@@ -86,13 +85,14 @@ class ResourceController extends Controller
             $coordinate = explode(',', Auth::user()->capital);
             $result = (new Policy())->addWithMe($coordinate[0], $coordinate[1], Policy::POLICIES_ENLISTING['id'], $endTime);
 
-            if (is_bool($result)) {
-                DB::commit();
-                return $endTime;
+            if ($result['status'] !== 200) {
+                throw new \Exception($result);
             }
+            DB::commit();
+            return $result['info'];
         } catch (\Exception $exception) {
             DB::rollBack();
-            return response($exception->getMessage(), 500);
+            return response($exception->getMessage()['info'], $exception->getMessage()['status']);
         }
     }
 
@@ -102,16 +102,16 @@ class ResourceController extends Controller
      * @title [动作]流民招募启示的进度
      * @description -
      * @method get
-     * @url https://{url}/lord/policy/enlisting/know
-     * @param x 必选 int X 坐标
-     * @param y 必选 int Y 坐标
+     * @url https://{url}/lord/policy/enlisting/know/{x}/{y}
+     * @param x 必选 int X坐标
+     * @param y 必选 int Y坐标
      * @return {"id":26,"created_at":"2018-12-22 12:45:57","updated_at":"2018-12-24 01:24:47"}
      * @return_param id int 资源ID
      * @return_param created_at int 创建时间
      * @return_param updated_at int 更新时间
      * @number 50
      */
-    public function knowEnlisting()
+    public function knowEnlisting(int $x, int $y)
     {
         // 启动政策
         $coordinate = explode(',', Auth::user()->capital);
@@ -124,39 +124,63 @@ class ResourceController extends Controller
         } else {
             $endResult = rand(7, 10);
         }
-        $endInfo = '政策“' . Policy::POLICIES_TRANS[0] . '”已结束，我们募集到' . $endResult . '个流浪人。';
-        $result = (new Policy())->getStatus($coordinate[0], $coordinate[1], Auth::id(), $endInfo);
+        $endInfo = '政策“' . Policy::POLICIES_TRANS[1] . '”已结束，有' . $endResult . '位流浪人投靠我们。';
 
-        if ($result['status'] === 200) {
-            return $result;
+        DB::beginTransaction();
+        try {
+            $result = (new Policy())->getStatus($coordinate[0], $coordinate[1], Auth::id(), $endInfo);
+
+            if ($result['status'] !== 200) {
+                throw new \Exception($result);
+            }
+
+            if (is_string($result['info'])) {
+                $resource = Resource::where('userId', Auth::id())->first();
+                $resource->people += $endResult;
+                if (!$resource->save()) {
+                    throw new \Exception(['status' => 500, 'info' => '保存新增流浪人失败']);
+                }
+            }
+
+            DB::commit();
+            return $result['info'];
+        } catch (\Exception $exception) {
+            DB::rollBack();
+            return response($exception->getMessage()['info'], $exception->getMessage()['status']);
         }
-
-        return response($result, $result['status']);
     }
 
     /**
      * showdoc
      * @catalog 前后端接口/领地
      * @title [动作]终止流民招募启示
-     * @description 发布流民招募启示，在 20 秒后结束招募
+     * @description 直接结束招募，但不退还发执行政令的费用
      * @method get
-     * @url https://{url}/lord/policy/enlisting/stop
+     * @url https://{url}/lord/policy/enlisting/stop/{x}/{y}
+     * @param x 必选 int X坐标
+     * @param y 必选 int Y坐标
      * @return {"id":26,"created_at":"2018-12-22 12:45:57","updated_at":"2018-12-24 01:24:47"}
      * @return_param id int 资源ID
      * @return_param created_at int 创建时间
      * @return_param updated_at int 更新时间
      * @number 50
      */
-    public function stopEnlisting()
+    public function stopEnlisting(int $x, int $y)
     {
         // 启动政策
-        $endTime = Policy::POLICIES_ENLISTING['time'];
-        $result = (new Policy())->addWithMe(Policy::POLICIES_ENLISTING['id'], $endTime);
+        $coordinate = explode(',', Auth::user()->capital);
+        DB::beginTransaction();
+        try {
+            $result = (new Policy())->stopWithMe($coordinate[0], $coordinate[1]);
 
-        if (is_bool($result)) {
-            return $result;
+            if ($result['status'] !== 200) {
+                throw new \Exception($result);
+            }
+            DB::commit();
+            return $result['info'];
+        } catch (\Exception $exception) {
+            DB::rollBack();
+            return response($exception->getMessage()['info'], $exception->getMessage()['status']);
         }
-
-        return response($result, 500);
     }
 }

--- a/app/Http/Controllers/Common/ResourceController.php
+++ b/app/Http/Controllers/Common/ResourceController.php
@@ -86,13 +86,14 @@ class ResourceController extends Controller
             $result = (new Policy())->addWithMe($coordinate[0], $coordinate[1], Policy::POLICIES_ENLISTING['id'], $endTime);
 
             if ($result['status'] !== 200) {
-                throw new \Exception($result);
+                DB::rollBack();
+                return response($result['info'], $result['status']);
             }
             DB::commit();
             return $result['info'];
         } catch (\Exception $exception) {
             DB::rollBack();
-            return response($exception->getMessage()['info'], $exception->getMessage()['status']);
+            return response($exception->getMessage(), 500);
         }
     }
 
@@ -131,14 +132,15 @@ class ResourceController extends Controller
             $result = (new Policy())->getStatus($coordinate[0], $coordinate[1], Auth::id(), $endInfo);
 
             if ($result['status'] !== 200) {
-                throw new \Exception($result);
+                DB::rollBack();
+                return response($result['info'], $result['status']);
             }
 
             if (is_string($result['info'])) {
                 $resource = Resource::where('userId', Auth::id())->first();
                 $resource->people += $endResult;
                 if (!$resource->save()) {
-                    throw new \Exception(['status' => 500, 'info' => '保存新增流浪人失败']);
+                    throw new \Exception('保存新增流浪人失败');
                 }
             }
 
@@ -146,7 +148,7 @@ class ResourceController extends Controller
             return $result['info'];
         } catch (\Exception $exception) {
             DB::rollBack();
-            return response($exception->getMessage()['info'], $exception->getMessage()['status']);
+            return response($exception->getMessage(), 500);
         }
     }
 
@@ -174,13 +176,14 @@ class ResourceController extends Controller
             $result = (new Policy())->stopWithMe($coordinate[0], $coordinate[1]);
 
             if ($result['status'] !== 200) {
-                throw new \Exception($result);
+                DB::rollBack();
+                return response($result['info'], $result['status']);
             }
             DB::commit();
             return $result['info'];
         } catch (\Exception $exception) {
             DB::rollBack();
-            return response($exception->getMessage()['info'], $exception->getMessage()['status']);
+            return response($exception->getMessage(), 500);
         }
     }
 }

--- a/app/Http/Controllers/Common/ResourceController.php
+++ b/app/Http/Controllers/Common/ResourceController.php
@@ -8,6 +8,7 @@ use App\Policy;
 use App\Service\LogService;
 use Illuminate\Support\Facades\Auth;
 use App\Http\Controllers\Controller;
+use Illuminate\Support\Facades\DB;
 
 class ResourceController extends Controller
 {
@@ -57,15 +58,18 @@ class ResourceController extends Controller
      * showdoc
      * @catalog 前后端接口/领地
      * @title [动作]发布流民招募启示
-     * @description 该政令耗费 10 金钱，返回政令的结束时间戳，届时，需前端发起请求，获取该政令的状态并提示给用户
+     * @description 在坐标为 X,Y 的领土上，施展政令。该政令耗费 10 金钱，返回政令的结束时间戳，届时，需前端发起请求，获取该政令的状态并提示给用户
      * @method get
      * @url https://{url}/lord/policy/enlisting/open
+     * @param x 必选 int X 坐标
+     * @param y 必选 int Y 坐标
      * @return {1546777084}
      * @return_param - int|string 政令完成的时间戳或失败原因
      * @number 50
      */
     public function openEnlisting()
     {
+        // 扣除资源
         $resource = Resource::where('userId', Auth::id())->first();
         if ($resource->money < 10) {
             return response('大爷，咱们的钱不够啦！', 400);
@@ -76,25 +80,19 @@ class ResourceController extends Controller
             if (!$resource->save()) {
                 return '失败：付钱行为无法保存';
             }
+
+            // 启动政策
+            $endTime = Policy::POLICIES_ENLISTING['time'] + $_SERVER['REQUEST_TIME'];
+            $result = (new Policy())->addWithMe(Policy::POLICIES_ENLISTING['id'], $endTime);
+
+            if (is_bool($result)) {
+                DB::commit();
+                return $endTime;
+            }
         } catch (\Exception $exception) {
             DB::rollBack();
-            return $exception->getMessage();
+            return response($exception->getMessage(), 500);
         }
-
-        return '失败：移除政策';
-
-        // 启动政策
-        $endTime = Policy::POLICIES_ENLISTING['time'];
-        $result = (new Policy())->addWithMe(Policy::POLICIES_ENLISTING['id'], $endTime);
-
-        if (is_bool($result)) {
-            return $_SERVER['REQUEST_TIME'] + Policy::POLICIES_ENLISTING['time'];
-        }
-
-        $resource->money += 10;
-        $resource->save();
-
-        return response($result, 500);
     }
 
     /**
@@ -104,6 +102,8 @@ class ResourceController extends Controller
      * @description -
      * @method get
      * @url https://{url}/lord/policy/enlisting/know
+     * @param x 必选 int X 坐标
+     * @param y 必选 int Y 坐标
      * @return {"id":26,"created_at":"2018-12-22 12:45:57","updated_at":"2018-12-24 01:24:47"}
      * @return_param id int 资源ID
      * @return_param created_at int 创建时间
@@ -113,7 +113,6 @@ class ResourceController extends Controller
     public function knowEnlisting()
     {
         // 启动政策
-        $endTime = Policy::POLICIES_ENLISTING['time'];
         $result = (new Policy())->addWithMe(Policy::POLICIES_ENLISTING['id'], $endTime);
 
         if (is_bool($result)) {

--- a/app/Http/Controllers/Common/ResourceController.php
+++ b/app/Http/Controllers/Common/ResourceController.php
@@ -83,7 +83,8 @@ class ResourceController extends Controller
 
             // 启动政策
             $endTime = Policy::POLICIES_ENLISTING['time'] + $_SERVER['REQUEST_TIME'];
-            $result = (new Policy())->addWithMe(Policy::POLICIES_ENLISTING['id'], $endTime);
+            $coordinate = explode(',', Auth::user()->capital);
+            $result = (new Policy())->addWithMe($coordinate[0], $coordinate[1], Policy::POLICIES_ENLISTING['id'], $endTime);
 
             if (is_bool($result)) {
                 DB::commit();
@@ -113,13 +114,24 @@ class ResourceController extends Controller
     public function knowEnlisting()
     {
         // 启动政策
-        $result = (new Policy())->addWithMe(Policy::POLICIES_ENLISTING['id'], $endTime);
+        $coordinate = explode(',', Auth::user()->capital);
+        $percent = rand(1, 100);
+        // 10% 1-2; 60% 3-6; 30% 7-10; sum: 21.3
+        if ($percent < 10) {
+            $endResult = rand(1, 2);
+        } elseif ($percent < 70) {
+            $endResult = rand(3, 6);
+        } else {
+            $endResult = rand(7, 10);
+        }
+        $endInfo = '政策“' . Policy::POLICIES_TRANS[0] . '”已结束，我们募集到' . $endResult . '个流浪人。';
+        $result = (new Policy())->getStatus($coordinate[0], $coordinate[1], Auth::id(), $endInfo);
 
-        if (is_bool($result)) {
+        if ($result['status'] === 200) {
             return $result;
         }
 
-        return response($result, 500);
+        return response($result, $result['status']);
     }
 
     /**

--- a/app/Http/Controllers/Common/ResourceController.php
+++ b/app/Http/Controllers/Common/ResourceController.php
@@ -2,12 +2,12 @@
 
 namespace App\Http\Controllers\Common;
 
-
 use App\Models\Resource;
 use App\Policy;
 use Illuminate\Support\Facades\Auth;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Http\Request;
 
 class ResourceController extends Controller
 {
@@ -58,15 +58,15 @@ class ResourceController extends Controller
      * @catalog 前后端接口/领地
      * @title [动作]发布流民招募启示
      * @description 在坐标为 X,Y 的领土上，施展政令。该政令耗费 10 金钱，返回政令的结束时间戳，届时，需前端发起请求，获取该政令的状态并提示给用户
-     * @method get
-     * @url https://{url}/lord/policy/enlisting/open/{x}/{y}
+     * @method post
+     * @url https://{url}/lord/policy/enlisting/open
      * @param x 必选 int X坐标
      * @param y 必选 int Y坐标
-     * @return {1546777084}
+     * @return 1546777084
      * @return_param - int|string 政令完成的时间戳或失败原因
      * @number 50
      */
-    public function openEnlisting(int $x, int $y)
+    public function openEnlisting(Request $request)
     {
         // 扣除资源
         $resource = Resource::where('userId', Auth::id())->first();
@@ -76,21 +76,30 @@ class ResourceController extends Controller
         $resource->money -= 10;
         DB::beginTransaction();
         try {
+            $coordinate = explode(',', Auth::user()->capital);
+            $policy = Policy::where(['x' => $coordinate[0], 'y' => $coordinate[1], 'policiesKey' => Policy::POLICIES_ENLISTING['id'], 'status' => Policy::STATUS['doing']])->first();
+            if ($policy) {
+                $endInfo = '政策“' . Policy::POLICIES_TRANS[2] . '”结束了，我们狠心地驱逐了' . $policy->tips . '位居民。';
+                $check = (new Policy())->getStatus(Policy::POLICIES_DEPORTED['id'], Auth::id(), $coordinate[0], $coordinate[1], $endInfo);
+                if (is_numeric($check)) {
+                    return '政策实施中，请勿重复施政';
+                }
+            }
+
             if (!$resource->save()) {
                 return '失败：付钱行为无法保存';
             }
 
             // 启动政策
             $endTime = Policy::POLICIES_ENLISTING['time'] + $_SERVER['REQUEST_TIME'];
-            $coordinate = explode(',', Auth::user()->capital);
-            $result = (new Policy())->addWithMe($coordinate[0], $coordinate[1], Policy::POLICIES_ENLISTING['id'], $endTime);
+            $result = (new Policy())->addWithMe(Policy::POLICIES_ENLISTING['id'], $coordinate[0], $coordinate[1], $endTime);
 
-            if ($result['status'] !== 200) {
+            if (is_array($result) && $result['status'] !== 200) {
                 DB::rollBack();
                 return response($result['info'], $result['status']);
             }
             DB::commit();
-            return $result['info'];
+            return $result;
         } catch (\Exception $exception) {
             DB::rollBack();
             return response($exception->getMessage(), 500);
@@ -129,15 +138,15 @@ class ResourceController extends Controller
 
         DB::beginTransaction();
         try {
-            $result = (new Policy())->getStatus($coordinate[0], $coordinate[1], Auth::id(), $endInfo);
+            $result = (new Policy())->getStatus(Policy::POLICIES_ENLISTING['id'], Auth::id(), $coordinate[0], $coordinate[1], $endInfo);
 
-            if ($result['status'] !== 200) {
+            if (is_array($result) && $result['status'] !== 200) {
                 DB::rollBack();
                 return response($result['info'], $result['status']);
             }
 
             // 增加资源
-            if (is_string($result['info'])) {
+            if (!is_array($result) && $result === $endInfo) {
                 $resource = Resource::where('userId', Auth::id())->first();
                 $resource->people += $endResult;
                 if (!$resource->save()) {
@@ -146,7 +155,7 @@ class ResourceController extends Controller
             }
 
             DB::commit();
-            return $result['info'];
+            return $result;
         } catch (\Exception $exception) {
             DB::rollBack();
             return response($exception->getMessage(), 500);
@@ -162,7 +171,7 @@ class ResourceController extends Controller
      * @url https://{url}/lord/policy/enlisting/stop/{x}/{y}
      * @param x 必选 int X坐标
      * @param y 必选 int Y坐标
-     * @return {"id":26,"created_at":"2018-12-22 12:45:57","updated_at":"2018-12-24 01:24:47"}
+     * @return 政策已终止
      * @return_param id int 资源ID
      * @return_param created_at int 创建时间
      * @return_param updated_at int 更新时间
@@ -174,14 +183,14 @@ class ResourceController extends Controller
         $coordinate = explode(',', Auth::user()->capital);
         DB::beginTransaction();
         try {
-            $result = (new Policy())->stopWithMe($coordinate[0], $coordinate[1]);
+            $result = (new Policy())->stopWithMe(Policy::POLICIES_ENLISTING['id'], $coordinate[0], $coordinate[1]);
 
-            if ($result['status'] !== 200) {
+            if (is_array($result) && $result['status'] !== 200) {
                 DB::rollBack();
                 return response($result['info'], $result['status']);
             }
             DB::commit();
-            return $result['info'];
+            return $result;
         } catch (\Exception $exception) {
             DB::rollBack();
             return response($exception->getMessage(), 500);
@@ -191,41 +200,67 @@ class ResourceController extends Controller
     /**
      * showdoc
      * @catalog 前后端接口/领地
-     * @title [动作]发布流民招募启示
-     * @description 在坐标为 X,Y 的领土上，施展政令。该政令耗费 10 金钱，返回政令的结束时间戳，届时，需前端发起请求，获取该政令的状态并提示给用户
-     * @method get
-     * @url https://{url}/lord/policy/enlisting/open/{x}/{y}
+     * @title [动作]发布居民驱逐通告
+     * @description 在坐标为 X,Y 的领土上，施展政令。该政令将驱逐特定数量的居民，并为背井离乡者提供一定的遣散费用（每人/5金钱或3食物）。
+     * @method post
+     * @url https://{url}/lord/policy/deported/open
      * @param x 必选 int X坐标
      * @param y 必选 int Y坐标
-     * @return {1546777084}
+     * @param costType 必选 int 支付的资源类型（1：金钱、2：食物）
+     * @param number 必选 int 被驱逐居民的数量
+     * @return 1547489763
      * @return_param - int|string 政令完成的时间戳或失败原因
      * @number 50
      */
-    public function openDeported(int $x, int $y)
+    public function openDeported(Request $request)
     {
+        $number = (int)$request['number'];
+        $costName = false;
+        $costNumber = 0;
+        if ($request['costType'] == 1) {
+            $costName = 'money';
+            $costNumber = $number * 5;
+        } elseif ($request['costType'] == 2) {
+            $costName = 'food';
+            $costNumber = $number * 3;
+        }
+
+        if (!$number || !$costName) {
+            return response('参数错误', 400);
+        }
         // 扣除资源
         $resource = Resource::where('userId', Auth::id())->first();
-        if ($resource->money < 10) {
+        if ($resource->$costName < $costNumber) {
             return response('大爷，咱们的钱不够啦！', 400);
         }
-        $resource->money -= 10;
+        $coordinate = explode(',', Auth::user()->capital);
+        $resource->$costName -= $costNumber;
         DB::beginTransaction();
         try {
+            // 检查施政状态
+            $policy = Policy::where(['x' => $coordinate[0], 'y' => $coordinate[1], 'policiesKey' => Policy::POLICIES_DEPORTED['id'], 'status' => Policy::STATUS['doing']])->first();
+            if ($policy) {
+                $endInfo = '政策“' . Policy::POLICIES_TRANS[2] . '”结束了，我们狠心地驱逐了' . $policy->tips . '位居民。';
+                $check = (new Policy())->getStatus(Policy::POLICIES_DEPORTED['id'], Auth::id(), $coordinate[0], $coordinate[1], $endInfo);
+                if (is_numeric($check)) {
+                    return '政策实施中，请勿重复施政';
+                }
+            }
+
             if (!$resource->save()) {
-                return '失败：付钱行为无法保存';
+                return response(500, '支付无法保存');
             }
 
             // 启动政策
-            $endTime = Policy::POLICIES_ENLISTING['time'] + $_SERVER['REQUEST_TIME'];
-            $coordinate = explode(',', Auth::user()->capital);
-            $result = (new Policy())->addWithMe($coordinate[0], $coordinate[1], Policy::POLICIES_ENLISTING['id'], $endTime);
+            $endTime = Policy::POLICIES_DEPORTED['time'] + $_SERVER['REQUEST_TIME'];
+            $result = (new Policy())->addWithMe(Policy::POLICIES_DEPORTED['id'], $coordinate[0], $coordinate[1], $endTime, $number);
 
-            if ($result['status'] !== 200) {
+            if (is_array($result) && $result['status'] !== 200) {
                 DB::rollBack();
                 return response($result['info'], $result['status']);
             }
             DB::commit();
-            return $result['info'];
+            return $result;
         } catch (\Exception $exception) {
             DB::rollBack();
             return response($exception->getMessage(), 500);
@@ -235,10 +270,10 @@ class ResourceController extends Controller
     /**
      * showdoc
      * @catalog 前后端接口/领地
-     * @title [动作]流民招募启示的进度
+     * @title [动作]居民驱逐通告的进度
      * @description -
      * @method get
-     * @url https://{url}/lord/policy/enlisting/know/{x}/{y}
+     * @url https://{url}/lord/policy/deported/know/{x}/{y}
      * @param x 必选 int X坐标
      * @param y 必选 int Y坐标
      * @return {"id":26,"created_at":"2018-12-22 12:45:57","updated_at":"2018-12-24 01:24:47"}
@@ -249,39 +284,32 @@ class ResourceController extends Controller
      */
     public function knowDeported(int $x, int $y)
     {
-        // 启动政策
+        // 检查
         $coordinate = explode(',', Auth::user()->capital);
-        $percent = rand(1, 100);
-        // 10% 1-2; 60% 3-6; 30% 7-10; sum: 21.3
-        if ($percent < 10) {
-            $endResult = rand(1, 2);
-        } elseif ($percent < 70) {
-            $endResult = rand(3, 6);
-        } else {
-            $endResult = rand(7, 10);
+        $policy = Policy::where(['x' => $coordinate[0], 'y' => $coordinate[1], 'policiesKey' => Policy::POLICIES_DEPORTED['id'], 'status' => Policy::STATUS['doing']])->first();
+        if (!$policy) {
+            return '这片土地尚未施行该政策，或该政策已失效';
         }
-        $endInfo = '政策“' . Policy::POLICIES_TRANS[1] . '”已结束，有' . $endResult . '位流浪人投靠我们。';
 
+        $endInfo = '政策“' . Policy::POLICIES_TRANS[2] . '”结束了，我们狠心地驱逐了' . $policy->tips . '位居民。';
         DB::beginTransaction();
         try {
-            $result = (new Policy())->getStatus($coordinate[0], $coordinate[1], Auth::id(), $endInfo);
+            $result = (new Policy())->getStatus(Policy::POLICIES_DEPORTED['id'], Auth::id(), $coordinate[0], $coordinate[1], $endInfo);
 
-            if ($result['status'] !== 200) {
+            if (is_array($result) && $result['status'] !== 200) {
                 DB::rollBack();
                 return response($result['info'], $result['status']);
             }
 
             // 增加资源
-            if (is_string($result['info'])) {
-                $resource = Resource::where('userId', Auth::id())->first();
-                $resource->people += $endResult;
-                if (!$resource->save()) {
-                    throw new \Exception('保存新增流浪人失败');
-                }
+            $resource = Resource::where('userId', Auth::id())->first();
+            $resource->people -= $policy->tips;
+            if (!$resource->save()) {
+                throw new \Exception('保存驱逐居民失败');
             }
 
             DB::commit();
-            return $result['info'];
+            return $result;
         } catch (\Exception $exception) {
             DB::rollBack();
             return response($exception->getMessage(), 500);
@@ -294,10 +322,10 @@ class ResourceController extends Controller
      * @title [动作]终止流民招募启示
      * @description 直接结束招募，但不退还发执行政令的费用
      * @method get
-     * @url https://{url}/lord/policy/enlisting/stop/{x}/{y}
+     * @url https://{url}/lord/policy/deported/stop/{x}/{y}
      * @param x 必选 int X坐标
      * @param y 必选 int Y坐标
-     * @return {"id":26,"created_at":"2018-12-22 12:45:57","updated_at":"2018-12-24 01:24:47"}
+     * @return 政策已终止
      * @return_param id int 资源ID
      * @return_param created_at int 创建时间
      * @return_param updated_at int 更新时间
@@ -309,14 +337,14 @@ class ResourceController extends Controller
         $coordinate = explode(',', Auth::user()->capital);
         DB::beginTransaction();
         try {
-            $result = (new Policy())->stopWithMe($coordinate[0], $coordinate[1]);
-
-            if ($result['status'] !== 200) {
+            $result = (new Policy())->stopWithMe(Policy::POLICIES_DEPORTED['id'], $coordinate[0], $coordinate[1]);
+            if (is_array($result) && $result['status'] !== 200) {
                 DB::rollBack();
                 return response($result['info'], $result['status']);
             }
+
             DB::commit();
-            return $result['info'];
+            return $result;
         } catch (\Exception $exception) {
             DB::rollBack();
             return response($exception->getMessage(), 500);

--- a/app/Policy.php
+++ b/app/Policy.php
@@ -21,6 +21,16 @@ class Policy extends Model
         'time' => 100,
     ];
 
+    public function findStatus(string $coordinate, int $userId = 0)
+    {
+        if (!$userId) {
+            $userId = Auth::id();
+        }
+
+        // TODO: 检查政令是否执行完毕，完毕则加入日志、未完则返回完成时间
+        $policy = self::find($userId);
+    }
+
     /**
      * 为用户自己启用政策
      *

--- a/app/UserHistory.php
+++ b/app/UserHistory.php
@@ -12,16 +12,32 @@ use Illuminate\Database\Eloquent\Model;
  * @property int x X 坐标
  * @property int y Y 坐标
  * @property string info 文字描述
+ * @property string category 类型
  */
 class UserHistory extends Model
 {
-    public static function add(int $userId, int $x, int $y, string $endInfo)
+    public const CATEGORY = [
+        'policy' => 1,
+    ];
+
+    /**
+     * 新增日志
+     *
+     * @param int $userId
+     * @param int $x
+     * @param int $y
+     * @param string $endInfo
+     * @param int $category
+     * @return array|bool
+     */
+    public static function add(int $userId, int $x, int $y, string $endInfo, int $category)
     {
         $userHistory = new self();
         $userHistory->userId = $userId;
         $userHistory->x = $x;
         $userHistory->y = $y;
         $userHistory->info = $endInfo;
+        $userHistory->category = $category;
 
         if (!$userHistory->save()) {
             return ['status' => 500, 'info' => '政策日志保存失败'];

--- a/app/UserHistory.php
+++ b/app/UserHistory.php
@@ -4,11 +4,29 @@ namespace App;
 
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * Class UserHistory
+ *
+ * @package App
+ * @property int userId 用户名
+ * @property int x X 坐标
+ * @property int y Y 坐标
+ * @property string info 文字描述
+ */
 class UserHistory extends Model
 {
-    public const STATUS = [
-        'stop' => 0,
-        'end' => 1,
-        'doing' => 2,
-    ];
+    public static function add(int $userId, int $x, int $y, string $endInfo)
+    {
+        $userHistory = new self();
+        $userHistory->userId = $userId;
+        $userHistory->x = $x;
+        $userHistory->y = $y;
+        $userHistory->info = $endInfo;
+
+        if (!$userHistory->save()) {
+            return ['status' => 500, 'info' => '政策日志保存失败'];
+        }
+
+        return false;
+    }
 }

--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -20,7 +20,7 @@ class CreateUsersTable extends Migration
             $table->string('email')->unique(); # 邮箱（登录名）
             $table->string('password', 64); # 密码
             $table->string('kingdom', 12); # 王国名
-            $table->string('capital', 12); # 首都
+            $table->string('capital', 10); # 首都
             $table->rememberToken();
             $table->timestamps();
         });

--- a/database/migrations/2019_01_06_165653_create_user_histories_table.php
+++ b/database/migrations/2019_01_06_165653_create_user_histories_table.php
@@ -16,6 +16,8 @@ class CreateUserHistoriesTable extends Migration
         Schema::create('user_histories', function (Blueprint $table) {
             $table->increments('id');
             $table->unsignedInteger('userId');
+            $table->unsignedInteger('x'); # X 坐标
+            $table->unsignedInteger('y'); # Y 坐标
             $table->string('info', 144); # 历史信息
             $table->unsignedTinyInteger('status')->default(0);
             $table->timestamps(); # 时间使用 created_at

--- a/database/migrations/2019_01_06_165653_create_user_histories_table.php
+++ b/database/migrations/2019_01_06_165653_create_user_histories_table.php
@@ -19,7 +19,7 @@ class CreateUserHistoriesTable extends Migration
             $table->unsignedInteger('x'); # X 坐标
             $table->unsignedInteger('y'); # Y 坐标
             $table->string('info', 144); # 历史信息
-            $table->unsignedTinyInteger('status')->default(0);
+            $table->unsignedTinyInteger('category');
             $table->timestamps(); # 时间使用 created_at
         });
     }

--- a/database/migrations/2019_01_06_174250_create_policies_table.php
+++ b/database/migrations/2019_01_06_174250_create_policies_table.php
@@ -21,6 +21,7 @@ class CreatePoliciesTable extends Migration
             $table->unsignedMediumInteger('policiesKey'); # 政策编号
             $table->string('title', 30); # 标题
             $table->unsignedInteger('endTime'); # 结束时间
+            $table->unsignedTinyInteger('status')->default(0);
             $table->string('tips', 1000)->nullable(); # 备注，闲置字段，供复杂功能使用
             $table->timestamps();
         });

--- a/database/migrations/2019_01_06_174250_create_policies_table.php
+++ b/database/migrations/2019_01_06_174250_create_policies_table.php
@@ -16,7 +16,8 @@ class CreatePoliciesTable extends Migration
         Schema::create('policies', function (Blueprint $table) {
             $table->increments('id');
             $table->unsignedInteger('userId'); # 用户 ID，仅作为锚定，地点被占领后，不影响政策实行
-            $table->string('capital', 12); # 坐标
+            $table->unsignedInteger('x'); # X 坐标
+            $table->unsignedInteger('y'); # Y 坐标
             $table->unsignedMediumInteger('policiesKey'); # 政策编号
             $table->string('title', 30); # 标题
             $table->unsignedInteger('endTime'); # 结束时间

--- a/database/seeds/UsersTableSeeder.php
+++ b/database/seeds/UsersTableSeeder.php
@@ -13,7 +13,7 @@ class UsersTableSeeder extends Seeder
     {
         $_COOKIE['id'] = 0;
 
-        factory(App\User::class, 25)
+        factory(App\User::class, 10)
             ->create()
             ->each(
                 function ($u) {

--- a/frontend/src/components/sub/progress.vue
+++ b/frontend/src/components/sub/progress.vue
@@ -89,7 +89,3 @@
     color: #a8a9a6;
   }
 </style>
-
-<style scoped lang="scss">
-  @import "../../assets/scss/mycss_lib";
-</style>

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,12 +23,12 @@ Route::get ('/logout', 'Common\UserController@logout');
 
 // 领地
 Route::get ('/user/get-resource', 'Common\ResourceController@getMeResource')->middleware('resource.auto');
-Route::get ('/lord/policy/enlisting/open', 'Common\ResourceController@openEnlisting')->middleware('resource.auto');
-Route::get ('/lord/policy/enlisting/stop', 'Common\ResourceController@stopEnlisting')->middleware('resource.auto');
-Route::get ('/lord/policy/enlisting/know', 'Common\ResourceController@knowEnlisting')->middleware('resource.auto');
-Route::get ('/lord/policy/deported/open', 'Common\ResourceController@openDeported')->middleware('resource.auto');
-Route::get ('/lord/policy/deported/stop', 'Common\ResourceController@stopDeported')->middleware('resource.auto');
-Route::get ('/lord/policy/deported/know', 'Common\ResourceController@knowDeported')->middleware('resource.auto');
+Route::get ('/lord/policy/enlisting/open/{x}/{y}', 'Common\ResourceController@openEnlisting')->middleware('resource.auto');
+Route::get ('/lord/policy/enlisting/stop/{x}/{y}', 'Common\ResourceController@stopEnlisting')->middleware('resource.auto');
+Route::get ('/lord/policy/enlisting/know/{x}/{y}', 'Common\ResourceController@knowEnlisting')->middleware('resource.auto');
+Route::get ('/lord/policy/deported/open/{x}/{y}', 'Common\ResourceController@openDeported')->middleware('resource.auto');
+Route::get ('/lord/policy/deported/stop/{x}/{y}', 'Common\ResourceController@stopDeported')->middleware('resource.auto');
+Route::get ('/lord/policy/deported/know/{x}/{y}', 'Common\ResourceController@knowDeported')->middleware('resource.auto');
 
 // 建筑
 Route::get ('/building/index', 'Building\BuildingController@index')->middleware('resource.auto');

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,10 +23,10 @@ Route::get ('/logout', 'Common\UserController@logout');
 
 // 领地
 Route::get ('/user/get-resource', 'Common\ResourceController@getMeResource')->middleware('resource.auto');
-Route::get ('/lord/policy/enlisting/open/{x}/{y}', 'Common\ResourceController@openEnlisting')->middleware('resource.auto');
+Route::post('/lord/policy/enlisting/open', 'Common\ResourceController@openEnlisting')->middleware('resource.auto');
 Route::get ('/lord/policy/enlisting/stop/{x}/{y}', 'Common\ResourceController@stopEnlisting')->middleware('resource.auto');
 Route::get ('/lord/policy/enlisting/know/{x}/{y}', 'Common\ResourceController@knowEnlisting')->middleware('resource.auto');
-Route::get ('/lord/policy/deported/open/{x}/{y}', 'Common\ResourceController@openDeported')->middleware('resource.auto');
+Route::post('/lord/policy/deported/open', 'Common\ResourceController@openDeported')->middleware('resource.auto');
 Route::get ('/lord/policy/deported/stop/{x}/{y}', 'Common\ResourceController@stopDeported')->middleware('resource.auto');
 Route::get ('/lord/policy/deported/know/{x}/{y}', 'Common\ResourceController@knowDeported')->middleware('resource.auto');
 

--- a/tests/Feature/BuildingTest.php
+++ b/tests/Feature/BuildingTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit;
+namespace Tests\Feature;
 
 use App\User;
 use Tests\TestCase;

--- a/tests/Feature/ResourcePolicyTest.php
+++ b/tests/Feature/ResourcePolicyTest.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace Tests\Unit;
+namespace Tests\Feature;
 
 use App\User;
 use Tests\TestCase;
 
-class BuildingTest extends TestCase
+class ResourcePolicyTest extends TestCase
 {
     /**
-     * 获取建筑列表
+     * 终止政令（不存在）
      */
     public function testBuildingList()
     {
@@ -18,7 +18,7 @@ class BuildingTest extends TestCase
         initDevelopment();
 
         // Logic
-        $user = User::find(16);
+        $user = User::find(1);
         $response = $this->actingAs($user)
             ->json('GET', '/building/list');
 
@@ -26,11 +26,11 @@ class BuildingTest extends TestCase
     }
 
     /**
-     * 获取建筑进程（无）
+     * 获取政令进度（不存在）
      */
     public function testSchedule()
     {
-        $user = User::find(16);
+        $user = User::find(1);
         $response = $this->actingAs($user)
             ->json('GET', '/building/schedule');
 
@@ -38,11 +38,11 @@ class BuildingTest extends TestCase
     }
 
     /**
-     * 建筑开始
+     * 启动政令
      */
     public function testBuild()
     {
-        $user = User::find(16);
+        $user = User::find(1);
         $response = $this->actingAs($user)
             ->json('POST', '/building/build', [
                 'type' => 'farm',
@@ -54,11 +54,11 @@ class BuildingTest extends TestCase
     }
 
     /**
-     * 获取建筑进程（一个）
+     * 获取政令进度（未完成）
      */
     public function testScheduleHasOne()
     {
-        $user = User::find(16);
+        $user = User::find(1);
         $response = $this->actingAs($user)
             ->json('GET', '/building/schedule');
 
@@ -66,11 +66,11 @@ class BuildingTest extends TestCase
     }
 
     /**
-     * 建筑拆除
+     * 终止政令（存在）
      */
     public function testDestroy()
     {
-        $user = User::find(16);
+        $user = User::find(1);
         $response = $this->actingAs($user)
             ->json('POST', '/building/destroy', [
                 'type' => 'farm',
@@ -82,33 +82,23 @@ class BuildingTest extends TestCase
     }
 
     /**
-     * 获取建筑进程（两个）
+     * 启动两次政令（前者尚未执行完毕）
      */
-    public function testScheduleHasZero()
+    public function testDestroy2()
     {
-        $user = User::find(16);
+        $user = User::find(1);
         $response = $this->actingAs($user)
-            ->json('GET', '/building/schedule');
-
-        $response->assertStatus(200);
-    }
-
-    /**
-     * 建筑取消拆除
-     */
-    public function testRecall()
-    {
-        $user = User::find(16);
-        $response = $this->actingAs($user)
-            ->json('POST', '/building/recall', [
-                'id' => 76,
+            ->json('POST', '/building/destroy', [
+                'type' => 'farm',
+                'level' => '1',
+                'number' => '3',
             ]);
 
         $response->assertStatus(200);
     }
 
     /**
-     * 获取建筑进程（一个）
+     * 获取政令进度（完成）
      */
     public function testScheduleHasOneAgain()
     {
@@ -117,7 +107,7 @@ class BuildingTest extends TestCase
         setBuildingListOnInstant();
 
         // Logic
-        $user = User::find(16);
+        $user = User::find(1);
         $response = $this->actingAs($user)
             ->json('GET', '/building/schedule');
 

--- a/tests/Feature/ResourcePolicyTest.php
+++ b/tests/Feature/ResourcePolicyTest.php
@@ -6,6 +6,11 @@ use App\User;
 use Tests\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
+// TODO: 尝试改写 time
+function time($timestamp = 0) {
+    return $timestamp ?: \time();
+}
+
 class ResourcePolicyTest extends TestCase
 {
     protected const USER_ID = 1;

--- a/tests/Feature/ResourcePolicyTest.php
+++ b/tests/Feature/ResourcePolicyTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\User;
+use Tests\TestCase;
+
+class BuildingTest extends TestCase
+{
+    /**
+     * 获取建筑列表
+     */
+    public function testBuildingList()
+    {
+        // Mock
+        $this->json('GET', '/reset/redis');
+        require_once 'testHelper.php';
+        initDevelopment();
+
+        // Logic
+        $user = User::find(16);
+        $response = $this->actingAs($user)
+            ->json('GET', '/building/list');
+
+        $response->assertStatus(200);
+    }
+
+    /**
+     * 获取建筑进程（无）
+     */
+    public function testSchedule()
+    {
+        $user = User::find(16);
+        $response = $this->actingAs($user)
+            ->json('GET', '/building/schedule');
+
+        $response->assertStatus(200);
+    }
+
+    /**
+     * 建筑开始
+     */
+    public function testBuild()
+    {
+        $user = User::find(16);
+        $response = $this->actingAs($user)
+            ->json('POST', '/building/build', [
+                'type' => 'farm',
+                'level' => '1',
+                'number' => '5',
+            ]);
+
+        $response->assertStatus(200);
+    }
+
+    /**
+     * 获取建筑进程（一个）
+     */
+    public function testScheduleHasOne()
+    {
+        $user = User::find(16);
+        $response = $this->actingAs($user)
+            ->json('GET', '/building/schedule');
+
+        $response->assertStatus(200);
+    }
+
+    /**
+     * 建筑拆除
+     */
+    public function testDestroy()
+    {
+        $user = User::find(16);
+        $response = $this->actingAs($user)
+            ->json('POST', '/building/destroy', [
+                'type' => 'farm',
+                'level' => '1',
+                'number' => '3',
+            ]);
+
+        $response->assertStatus(200);
+    }
+
+    /**
+     * 获取建筑进程（两个）
+     */
+    public function testScheduleHasZero()
+    {
+        $user = User::find(16);
+        $response = $this->actingAs($user)
+            ->json('GET', '/building/schedule');
+
+        $response->assertStatus(200);
+    }
+
+    /**
+     * 建筑取消拆除
+     */
+    public function testRecall()
+    {
+        $user = User::find(16);
+        $response = $this->actingAs($user)
+            ->json('POST', '/building/recall', [
+                'id' => 76,
+            ]);
+
+        $response->assertStatus(200);
+    }
+
+    /**
+     * 获取建筑进程（一个）
+     */
+    public function testScheduleHasOneAgain()
+    {
+        // Mock
+        require_once 'testHelper.php';
+        setBuildingListOnInstant();
+
+        // Logic
+        $user = User::find(16);
+        $response = $this->actingAs($user)
+            ->json('GET', '/building/schedule');
+
+        $response->assertStatus(200);
+
+        // UnMock
+        $this->json('GET', '/reset/redis');
+    }
+}

--- a/tests/Feature/ResourcePolicyTest.php
+++ b/tests/Feature/ResourcePolicyTest.php
@@ -4,17 +4,19 @@ namespace Tests\Feature;
 
 use App\User;
 use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class ResourcePolicyTest extends TestCase
 {
+    protected const USER_ID = 1;
+    protected const RAY_X = 2;
+    protected const RAY_Y = 2;
+
     public static function setUpBeforeClass()
     {
         // Mock
-        $i = new self();
-        $i->json('GET', '/reset/redis');
         require_once 'testHelper.php';
         initDevelopment();
-        setBuildingListOnInstant();
     }
 
     /**
@@ -22,11 +24,12 @@ class ResourcePolicyTest extends TestCase
      */
     public function testBuildingList()
     {
-        $user = User::find(1);
+        $user = User::find(self::USER_ID);
         $response = $this->actingAs($user)
-            ->json('GET', '/building/list');
+            ->json('GET', '/lord/policy/enlisting/stop/' . self::RAY_X . '/' . self::RAY_Y);
 
         $response->assertStatus(200);
+        $response->assertSee('这片土地尚未施行该政策，或该政策已失效');
     }
 
     /**
@@ -34,11 +37,12 @@ class ResourcePolicyTest extends TestCase
      */
     public function testSchedule()
     {
-        $user = User::find(1);
+        $user = User::find(self::USER_ID);
         $response = $this->actingAs($user)
-            ->json('GET', '/building/schedule');
+            ->json('GET', '/lord/policy/enlisting/know/' . self::RAY_X . '/' . self::RAY_Y);
 
         $response->assertStatus(200);
+        $response->assertSee('这片土地尚未施行该政策');
     }
 
     /**
@@ -46,15 +50,12 @@ class ResourcePolicyTest extends TestCase
      */
     public function testBuild()
     {
-        $user = User::find(1);
+        $user = User::find(self::USER_ID);
         $response = $this->actingAs($user)
-            ->json('POST', '/building/build', [
-                'type' => 'farm',
-                'level' => '1',
-                'number' => '5',
-            ]);
+            ->json('GET', '/lord/policy/enlisting/open/' . self::RAY_X . '/' . self::RAY_Y);
 
         $response->assertStatus(200);
+        $this->assertTrue(is_numeric($response->getContent()));
     }
 
     /**
@@ -62,11 +63,12 @@ class ResourcePolicyTest extends TestCase
      */
     public function testScheduleHasOne()
     {
-        $user = User::find(1);
+        $user = User::find(self::USER_ID);
         $response = $this->actingAs($user)
-            ->json('GET', '/building/schedule');
+            ->json('GET', '/lord/policy/enlisting/know/' . self::RAY_X . '/' . self::RAY_Y);
 
         $response->assertStatus(200);
+        $this->assertTrue(is_numeric($response->getContent()));
     }
 
     /**
@@ -74,50 +76,46 @@ class ResourcePolicyTest extends TestCase
      */
     public function testDestroy()
     {
-        $user = User::find(1);
+        // 第一次
+        $user = User::find(self::USER_ID);
         $response = $this->actingAs($user)
-            ->json('POST', '/building/destroy', [
-                'type' => 'farm',
-                'level' => '1',
-                'number' => '3',
-            ]);
+            ->json('GET', '/lord/policy/enlisting/stop/' . self::RAY_X . '/' . self::RAY_Y);
 
         $response->assertStatus(200);
+        $this->assertTrue(is_numeric($response->getContent()));
+
+        // 第二次
+        $response = $this->actingAs($user)
+            ->json('GET', '/lord/policy/enlisting/stop/' . self::RAY_X . '/' . self::RAY_Y);
+
+        $response->assertStatus(200);
+        $response->assertSee('被废止');
     }
 
     /**
-     * 启动两次政令（前者尚未执行完毕）
+     * 同时启动两次政令
      */
     public function testDestroy2()
     {
-        $user = User::find(1);
+        $user = User::find(self::USER_ID);
         $response = $this->actingAs($user)
-            ->json('POST', '/building/destroy', [
-                'type' => 'farm',
-                'level' => '1',
-                'number' => '3',
-            ]);
+            ->json('GET', '/lord/policy/enlisting/stop/' . self::RAY_X . '/' . self::RAY_Y);
 
         $response->assertStatus(200);
+        $response->assertSee('被废止');
     }
-
-    /**
-     * 获取政令进度（完成）
-     */
-    public function testScheduleHasOneAgain()
-    {
-        // Logic
-        $user = User::find(1);
-        $response = $this->actingAs($user)
-            ->json('GET', '/building/schedule');
-
-        $response->assertStatus(200);
-    }
-
-    static public function tearDownAfterClass()
-    {
-        $i = new self();
-        $i->assertTrue(true);
-        $i->json('GET', '/reset/redis');
-    }
+//
+//    /**
+//     * 获取政令进度（完成）
+//     */
+//    public function testScheduleHasOneAgain()
+//    {
+//        // Logic
+//        $user = User::find(self::USER_ID);
+//        $response = $this->actingAs($user)
+//            ->json('GET', '/building/schedule');
+//
+//        $response->assertStatus(200);
+//        $response->assertSee('位流浪人投靠我们');
+//    }
 }

--- a/tests/Feature/ResourcePolicyTest.php
+++ b/tests/Feature/ResourcePolicyTest.php
@@ -7,17 +7,21 @@ use Tests\TestCase;
 
 class ResourcePolicyTest extends TestCase
 {
+    public static function setUpBeforeClass()
+    {
+        // Mock
+        $i = new self();
+        $i->json('GET', '/reset/redis');
+        require_once 'testHelper.php';
+        initDevelopment();
+        setBuildingListOnInstant();
+    }
+
     /**
      * 终止政令（不存在）
      */
     public function testBuildingList()
     {
-        // Mock
-        $this->json('GET', '/reset/redis');
-        require_once 'testHelper.php';
-        initDevelopment();
-
-        // Logic
         $user = User::find(1);
         $response = $this->actingAs($user)
             ->json('GET', '/building/list');
@@ -102,18 +106,18 @@ class ResourcePolicyTest extends TestCase
      */
     public function testScheduleHasOneAgain()
     {
-        // Mock
-        require_once 'testHelper.php';
-        setBuildingListOnInstant();
-
         // Logic
         $user = User::find(1);
         $response = $this->actingAs($user)
             ->json('GET', '/building/schedule');
 
         $response->assertStatus(200);
+    }
 
-        // UnMock
-        $this->json('GET', '/reset/redis');
+    static public function tearDownAfterClass()
+    {
+        $i = new self();
+        $i->assertTrue(true);
+        $i->json('GET', '/reset/redis');
     }
 }

--- a/tests/Feature/UserTest.php
+++ b/tests/Feature/UserTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit;
+namespace Tests\Feature;
 
 use App\User;
 use Tests\TestCase;

--- a/tests/Unit/ExampleTest.php
+++ b/tests/Unit/ExampleTest.php
@@ -14,6 +14,8 @@ class ExampleTest extends TestCase
      */
     public function testBasicTest()
     {
+        // 执行结果 = 调用“执行方法”
+        // 断言结果 = 断言方法（执行结果）
         $this->assertTrue(true);
     }
 }


### PR DESCRIPTION
【需求】
增加“居民招募”、“居民驱逐”两种政策
BUG：移除意外保留的前端错误代码

【解决】
新增了表及业务逻辑

【备注】
文档：https://www.showdoc.cc/testnk?page_id=1448154547950026
原型：https://projects.invisionapp.com/freehand/document/zJzlnnNUr

已进行简单测试，**需补全测试代码**
SQL：线上尚未更新