### PR TITLE
修改building页面button标签的样式

### DIFF
--- a/frontend/src/components/building.vue
+++ b/frontend/src/components/building.vue
@@ -19,7 +19,7 @@
               <div class="building">
                 <p>
                   <span>建筑清单：</span>
-                  <span class="button farmWood"
+                  <span class="button farm-wood"
                         v-for="type in buildType"
                         @click="toggle(type)"
                         :key="type">{{typeTrans(type)}}</span>
@@ -283,7 +283,7 @@
 
 <style scoped lang="scss">
   @import "../assets/scss/global_css";
-  .farmWood {
+  .farm-wood {
     height: 30px;
     width: 50px;
     margin: 0 5px;

--- a/frontend/src/components/building.vue
+++ b/frontend/src/components/building.vue
@@ -19,7 +19,7 @@
               <div class="building">
                 <p>
                   <span>建筑清单：</span>
-                  <span style="padding: 2px; margin: 2px; color: #636363; border: 1px solid black;"
+                  <span class="button farmWood"
                         v-for="type in buildType"
                         @click="toggle(type)"
                         :key="type">{{typeTrans(type)}}</span>
@@ -283,4 +283,20 @@
 
 <style scoped lang="scss">
   @import "../assets/scss/global_css";
+  .farmWood {
+    height: 30px;
+    width: 50px;
+    margin: 0 5px;
+    align-content: center;
+    font-size: 15px;
+    background: #6d7973;
+  }
+  #number {
+    height: 20px;
+    border: 1px solid #c3c3c3;
+    border-radius: 10px;
+    padding-left: 6px;
+    color: #555555;
+    outline: none;
+  }
 </style>


### PR DESCRIPTION
### 需求：
统一按钮样式
### 内容：
调整building页面中，“建筑清单”后的[农场][伐木]按钮的样式。（之前遗漏的按钮）
### 其他：
对building页面“数量”后的input框样式进行优化。