### PR TITLE
增加 `npm build` 的自动编译及上线脚本

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,5 @@ package-lock.json
 
 /public/hot
 /public/storage
-/public/static
+/public/js
+/public/css

--- a/README.md
+++ b/README.md
@@ -26,14 +26,17 @@ npm install
 #           }
 #         },
 
-# serve with hot reload at localhost:8080 or other tips
+# Serve with hot reload at localhost:8080 or other tips
 npm run dev
 
-# build for production with minification
+# Build for production with minification
 # npm run build
 
-# build for production and view the bundle analyzer report
+# Build for production and view the bundle analyzer report
 # npm run build --report
+
+# If you want auto build & publish, run it:
+# ./sh build
 
 # Test
 # run `./vendor/bin/phpunit [testFile]`, eg. `tests/Feature/ResourcePolicyTest.php`

--- a/frontend/config/index.js.bac
+++ b/frontend/config/index.js.bac
@@ -49,7 +49,7 @@ module.exports = {
 
     // Paths
     assetsRoot: path.resolve(__dirname, '../dist'),
-    assetsSubDirectory: 'static',
+    assetsSubDirectory: '',
     assetsPublicPath: '/',
 
     /**

--- a/sh
+++ b/sh
@@ -3,6 +3,15 @@
 if [ ${1} == "doc" ]; then
     cd app/Http
     ./showdoc_api.sh
+elif [ ${1} == "build" ]; then
+    rm -r public/css/*
+    rm -r public/js/*
+    cd frontend/
+    # rm -r dist/*
+    npm run build
+    mv dist/js/* ../public/js/
+    mv dist/css/* ../public/css/
+    mv dist/index.html ../resources/views/outside.php
 else
     cd frontend/
     npm run dev


### PR DESCRIPTION
#### 需求

为前端代码增加自动编译与上线脚本

#### 解决

已解决，未来分仓库后，只需维持当前文件目录结构，即可继续使用本脚本。